### PR TITLE
Start to UnitConversions (issue 28)

### DIFF
--- a/herms.cabal
+++ b/herms.cabal
@@ -63,7 +63,7 @@ data-dir:            data
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Utils, AddCLI, Types
+  exposed-modules:     Utils, AddCLI, Types, UnitConversions
   build-depends:       base >=4.8 && <5
                      , brick >=0.19 && <0.20
                      , directory >= 0.0

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -2,6 +2,7 @@ module UnitConversions where
 
 import Data.List
 import Data.Ratio
+import Types
 
 --unitType: 0 = Metric | 1 = Imperial
 convertRecipeUnits :: Int -> Recipe -> Recipe

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -3,11 +3,10 @@ module UnitConversions where
 import Data.List
 import Data.Ratio
 
-data Unit = Unit Metric | Imperial
-
-convertRecipeUnits :: Unit -> Recipe -> Recipe
+--unitType: 0 = Metric | 1 = Imperial
+convertRecipeUnits :: Int -> Recipe -> Recipe
 convertRecipeUnits un recp =
-    if un = Metric then
+    if un == 0 then
         recp{ingredients = map convertIngredientToMetric (ingredients recp)}
     else
         recp{ingredients = map convertIngredientToImperial (ingredients recp)}
@@ -19,8 +18,9 @@ convertIngredientToMetric ingr =
         "Tbsp"  -> ingr{quantity = qty * 15, unit = "mL"}
         "cup"   -> ingr{quantity = qty * 250, unit = "mL"}
         "oz"    -> ingr{quantity = qty * 28, unit = "g"}
+        _       -> ingr
     where
-        un = unit ingr,
+        un = unit ingr
         qty = quantity ingr
 
 convertIngredientToImperial :: Ingredient -> Ingredient
@@ -33,6 +33,7 @@ convertIngredientToImperial ingr =
                   else
                       ingr{quantity = qty / 250, unit = "cup"}
         "g"    -> ingr{quantity = qty / 28, unit = "oz"}
+        _      -> ingr
     where
-        un = unit ingr,
+        un = unit ingr
         qty = quantity ingr

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -1,0 +1,38 @@
+module UnitConversions where
+
+import Data.List
+import Data.Ratio
+
+data Unit = Unit Metric | Imperial
+
+convertRecipeUnits :: Unit -> Recipe -> Recipe
+convertRecipeUnits un recp =
+    if un = Metric then
+        recp{ingredients = map convertIngredientToMetric (ingredients recp)}
+    else
+        recp{ingredients = map convertIngredientToImperial (ingredients recp)}
+
+convertIngredientToMetric :: Ingredient -> Ingredient
+convertIngredientToMetric ingr =
+    case un of
+        "tsp"   -> ingr{quantity = qty * 5, unit = "mL"}
+        "Tbsp"  -> ingr{quantity = qty * 15, unit = "mL"}
+        "cup"   -> ingr{quantity = qty * 250, unit = "mL"}
+        "oz"    -> ingr{quantity = qty * 28, unit = "g"}
+    where
+        un = unit ingr,
+        qty = quantity ingr
+
+convertIngredientToImperial :: Ingredient -> Ingredient
+convertIngredientToImperial ingr =
+    case un of
+        "mL"   -> if qty < 15 then
+                      ingr{quantity = qty / 5, unit = "tsp"}
+                  else if qty < 250 then
+                      ingr{quantity = qty / 15, unit = "Tbsp"}
+                  else
+                      ingr{quantity = qty / 250, unit = "cup"}
+        "g"    -> ingr{quantity = qty / 28, unit = "oz"}
+    where
+        un = unit ingr,
+        qty = quantity ingr


### PR DESCRIPTION
In response to issue 28, this introduces `UnitConversions.hs` to `src`. Its `convertRecipeUnits` function takes a unit designation (`0` for metric, `1` for imperial) and a `Recipe`. It then returns a `Recipe` with units converted to the selected system.