### PR TITLE
Brick no longer supports GHC 7

### DIFF
--- a/herms.cabal
+++ b/herms.cabal
@@ -6,9 +6,9 @@ name:               herms
 
 -- The package description
 description:        HeRM's: a Haskell-based Recipe Manager for delicious kitchen recipes
-tested-with:        GHC == 7.10.3
-                    GHC == 8.0.2
+tested-with:        GHC == 8.0.2
                     GHC == 8.2.2
+                    GHC == 8.4.1
 
 -- The package version.  See the Haskell package versioning policy (PVP)
 -- for standards guiding when and how versions should be incremented.


### PR DESCRIPTION
Brick no longer supports GHC 7, so builds will fail with GHC versions lower than 8. Modifications will need to be made to Brick to offer legacy compatibility. 