### PR TITLE
No more legacy support for GHC 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
     - env: CABALVER=2.0 GHCVER=8.2.1
       compiler: ": #GHC 8.2.1"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.4.1
+      compiler: ": #GHC 8.4.1"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.1], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/herms.cabal
+++ b/herms.cabal
@@ -6,9 +6,9 @@ name:               herms
 
 -- The package description
 description:        HeRM's: a Haskell-based Recipe Manager for delicious kitchen recipes
-tested-with:        GHC == 7.10.3
-                    GHC == 8.0.2
+tested-with:        GHC == 8.4.1
                     GHC == 8.2.2
+                    GHC == 8.0.2
 
 -- The package version.  See the Haskell package versioning policy (PVP)
 -- for standards guiding when and how versions should be incremented.


### PR DESCRIPTION
Brick no longer supports GHC 7, so we will unfortunately not be able to either :(