### PR TITLE
Fix some bugs

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -12,7 +12,7 @@ stack setup
 stack build
 stack exec herms
 ```
-Whim-bam! 
+Whim-bam!
 
 ## Feature/Improvement Ideas
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,3 @@ Does this pull request address a current issue or idea in Contributing.md?
 Tell us what you did!
 
 Do you have any questions? :)
-

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ cabal install
 
 ### Usage
 
-#### Command-line interface 
+#### Command-line interface
 
-Herm's has a pretty intuitive interface for users familiar with other command-line programs! 
+Herm's has a pretty intuitive interface for users familiar with other command-line programs!
 
 Below is the exhaustive list of all commands and their functionalities. Take a gander!
 
@@ -79,7 +79,7 @@ Usage:
 
         herms list [-g|--group] [--tags TAGS]           list recipes
                    [--name-only ]
- 
+
         herms add                                       add a new recipe (interactively)
 
         herms edit RECIPE_NAME                          edit a recipe
@@ -90,7 +90,7 @@ Usage:
 
         herms view RECIPE_NAMES [-s|--serving INT]      view the particular recipes
                                 [-t|--step]
-                                [-c|--convert CONV_UNIT] 
+                                [-c|--convert CONV_UNIT]
 
         herms shopping RECIPE_NAMES [-s|--serving INT] generate shopping list for particular recipes
 

--- a/app/herms.hs
+++ b/app/herms.hs
@@ -426,9 +426,9 @@ optP =  subparser
                       (progDesc "show location of recipe and config files"))
 
 versionOption :: Parser (a -> a)
-versionOption = infoOption versionStr 
+versionOption = infoOption versionStr
                 (long "version"
-                <> short 'v' 
+                <> short 'v'
                 <> help "Show version")
 
 -- @prsr is the main parser of all CLI arguments.

--- a/app/herms.hs
+++ b/app/herms.hs
@@ -211,7 +211,8 @@ showRecipeInfo recipe = name ~~ "\n\t" ~~ desc ~~ "\n\t[Tags: " ~~ showTags ~~ "
 
 takeFullWords :: String -> String
 takeFullWords = unwords . takeFullWords' 0 . words
-  where takeFullWords' n [x]    | (length x + n) > 40 = []
+  where takeFullWords' _ []                           = []
+        takeFullWords' n [x]    | (length x + n) > 40 = []
                                 | otherwise           = [x]
         takeFullWords' n (x:xs) | (length x + n) > 40 = [x ++ "..."]
                                 | otherwise           =


### PR DESCRIPTION
# Does this pull request address a current issue or idea in Contributing.md?

It does fix two crashes, though there are no issues for them.

In particular, this fixes:
* a crash when no description is given for some recipe
* a crash when saving when the temporary file is on a different device from the recipe file

# Tell us what you did!

* Remove trailing whitespaces (fc90de4) (there is no harm in it and my editor does this automatically through `editorconfig`).
* Make `takeFullWords` total (2034141) (for finite lists, at least)
  
  `takeFullWords` was not total; specifically, it would fail on empty
  strings (such as blank descriptions in recipes).
* Fix `replaceDataFile` for different devices (0dfcd99)
  
  `replaceDataFile` would fail with `eXDEV` when moving the temp file to
  another device; this is circumvented by instead copying and then
  deleting the temp file if the error is thrown.

  This was taken from [this commit](https://github.com/commercialhaskell/hindent/commit/92831a83a976bc681a89bddd8b6fb69466752ecb) (which is pretty much the only thing which I could find on this problem).
