### PR TITLE
Add export functionality

### DIFF
--- a/app/herms.hs
+++ b/app/herms.hs
@@ -11,6 +11,7 @@ import Data.Function
 import Data.List
 import Data.Maybe
 import Data.Semigroup ((<>))
+import Data.String    (IsString(..))
 import Data.Ratio
 import Control.Applicative
 import Options.Applicative hiding (str)
@@ -127,6 +128,15 @@ importFile target = do
     putStrLn (t Str.importedRecipes)
     forM_ otherRecipeBook $ \recipe ->
       putStrLn $ "  " ++ recipeName recipe
+
+export :: [String] -> HermsReader IO ()
+export targets = do
+  (config, recipeBook) <- ask
+  let t = translator config
+  liftIO $ forM_ targets $ \ target ->
+    putText $ case readRecipeRef target recipeBook of
+      Nothing   -> target ~~ (t Str.doesNotExist)
+      Just recp -> fromString $ show recp
 
 getServingsAndConv :: Int -> String -> Config -> (Maybe Int, Conversion)
 getServingsAndConv serv convName config = (servings, conv)
@@ -318,6 +328,7 @@ runWithOpts (List tags group nameOnly)              = list tags group nameOnly
 runWithOpts Add                                     = add
 runWithOpts (Edit target)                           = edit target
 runWithOpts (Import target)                         = importFile target
+runWithOpts (Export targets)                        = export targets
 runWithOpts (Remove targets)                        = remove targets
 runWithOpts (View targets serving step conversion)  = if step 
                                                       then viewByStep targets serving conversion
@@ -336,15 +347,17 @@ data Command = List   [String] Bool Bool         -- ^ shows recipes
              | Add                               -- ^ adds the recipe (interactively)
              | Edit    String                    -- ^ edits the recipe
              | Import  String                    -- ^ imports a recipe file
+             | Export  [String]                  -- ^ exports recipes to stdout
              | Remove [String]                   -- ^ removes specified recipes
              | Shop   [String] Int               -- ^ generates the shopping list for given recipes
              | DataDir                           -- ^ prints the directory of recipe file and config.hs
 
-listP, addP, viewP, editP, importP, shopP, dataDirP :: Translator -> Parser Command
+listP, addP, viewP, editP, importP, exportP, shopP, dataDirP :: Translator -> Parser Command
 listP    t = List   <$> (words <$> (tagsP t)) <*> (groupByTagsP t) <*> (nameOnlyP t)
 addP     _ = pure Add
 editP    t = Edit   <$> (recipeNameP t)
 importP  t = Import <$> (fileNameP t)
+exportP  t = Export <$> (severalRecipesP t)
 removeP  t = Remove <$> (severalRecipesP t)
 viewP    t = View   <$> (severalRecipesP t) <*> (servingP t) <*> (stepP t) <*> (conversionP t)
 shopP    t = Shop   <$> (severalRecipesP t) <*> (servingP t)
@@ -433,6 +446,9 @@ optP t = subparser
      <> command (t Str.import')
                 (info  (helper <*> importP t)
                        (progDesc (t Str.importDesc)))
+     <> command (t Str.export)
+                (info  (helper <*> exportP t)
+                       (progDesc (t Str.exportDesc)))
      <> command (t Str.remove)
                 (info  (helper <*> removeP t)
                        (progDesc (t Str.removeDesc)))

--- a/src/Lang/Strings.hs
+++ b/src/Lang/Strings.hs
@@ -120,6 +120,9 @@ editDesc = "edit a recipe"
 import'    = "import"
 importDesc = "import a recipe file"
 
+export     = "export"
+exportDesc = "export recipes to stdout"
+
 remove     = "remove"
 removeDesc = "remove the particular recipes"
 


### PR DESCRIPTION
Fixes #59. It seems to me that recipes are imported with `read`, so exporting them is as easy as `show`. Let me know if I'm mistaken!

Of course, this will have to be changed to be maintained if #45 is implemented.