### PR TITLE
Update stack.yaml file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-10.9
+resolver: lts-12.12
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,40 +9,8 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- QuickCheck-2.9.2
-- StateVar-1.1.0.4
-- ansi-terminal-0.7.1.1
-- ansi-wl-pprint-0.6.8.1
-- blaze-builder-0.4.0.2
-- brick-0.19
-- colour-2.3.3
-- contravariant-1.4
-- data-clist-0.1.1.0
-- dlist-0.8.0.3
-- fail-4.9.0.0
-- hashable-1.2.6.1
-- microlens-0.4.8.0
-- microlens-mtl-0.1.11.0
-- microlens-th-0.4.1.1
-- mtl-2.2.1
-- optparse-applicative-0.14.0.0
-- parallel-3.2.1.1
-- parsec-3.1.11
-- primitive-0.6.2.0
-- random-1.1
-- semigroups-0.18.3
-- split-0.2.3.2
-- stm-2.4.4.1
-- tagged-0.8.5
-- text-zipper-0.10
-- tf-random-0.5
-- transformers-compat-0.5.1.4
-- unordered-containers-0.2.8.0
-- vector-0.12.0.1
-- void-0.7.2
-- vty-5.15.1
-- text-1.2.2.2
-- utf8-string-1.0.1.1
+- brick-0.41.2
+- vty-5.24
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Hi,

Just read from the `Contributing` file that you sue `stack` but the actual `stack.yaml` is broken:

```
In the dependencies for herms-1.9.0.4:
    brick-0.19 from stack configuration does not match >=0.41.2 && <=0.41.2  (latest matching version is 0.41.2)
    vty-5.15.1 from stack configuration does not match >=5.24 && <=5.24  (latest matching version is 5.24)
needed since herms is a build target.

Some different approaches to resolving this:

  * Set 'allow-newer: true' to ignore all version constraints and build anyway.

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be convenient when dealing with many
    complicated constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps in /home/nobrakal/Documents/prog/herms/stack.yaml:

- brick-0.41.2
- vty-5.24
```

and using an old `stackage-lts`.

Here is a general update that fix the build with `stack` and update `stack.yaml`:

* Update the stackage version from `10.9` to the latest `12.12`
* Remove most of the `extra-deps`, adding only what is needed.