### PR TITLE
Convert oven temperatures in recipe directions between Fahrenheit and Celsius (#39)

### DIFF
--- a/herms.cabal
+++ b/herms.cabal
@@ -89,7 +89,7 @@ library
                      , split >=0.2 && <0.3
                      , text >= 1.1 && <1.3
                      , yaml >=0.08 && <0.11
-                     , regex-posix >=0.95
+                     , regex-tdfa >=0.95
 
 executable herms
   hs-source-dirs:      app

--- a/herms.cabal
+++ b/herms.cabal
@@ -89,6 +89,7 @@ library
                      , split >=0.2 && <0.3
                      , text >= 1.1 && <1.3
                      , yaml >=0.08 && <0.11
+                     , regex-posix >=0.95
 
 executable herms
   hs-source-dirs:      app

--- a/herms.cabal
+++ b/herms.cabal
@@ -89,7 +89,7 @@ library
                      , split >=0.2 && <0.3
                      , text >= 1.1 && <1.3
                      , yaml >=0.08 && <0.11
-                     , regex-tdfa >=0.95
+                     , regex-tdfa >= 1.2.3 && <1.3
 
 executable herms
   hs-source-dirs:      app

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -13,8 +13,12 @@ convertRecipeUnits :: Conversion -> Recipe -> Recipe
 convertRecipeUnits unit recp =
   case unit of
     None        -> recp
-    Metric      -> recp{ingredients = map convertIngredientToMetric (ingredients recp)}
-    Imperial    -> recp{ingredients = map convertIngredientToImperial (ingredients recp)}
+    Metric      -> recp{
+      ingredients = map convertIngredientToMetric (ingredients recp),
+      directions = map convertTemperatureToMetric (directions recp)}
+    Imperial    -> recp{
+      ingredients = map convertIngredientToImperial (ingredients recp),
+      directions = map convertTemperatureToImperial (directions recp)}
 
 convertIngredientToMetric :: Ingredient -> Ingredient
 convertIngredientToMetric ingr =

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -76,7 +76,7 @@ findReplacements = map parseRegexResult . findTemperatures
   where parseRegexResult l = (l!!0, Temperature (read (l!!1)) (parseTempUnit (l!!2)))
 
 findTemperatures :: String -> [[String]]
-findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°(C|F)"
+findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)"
 
 parseTempUnit :: String -> TempUnit
 parseTempUnit "C" = C

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -3,7 +3,6 @@ module UnitConversions where
 import Types
 import Data.Text (replace, pack, unpack)
 import Text.Regex.TDFA ((=~))
-import Lens.Micro ((^?), ix)
 import Text.Read (readMaybe)
 import Data.Maybe (isJust,fromJust)
 
@@ -99,7 +98,9 @@ regexResultToTuple l =
         u = at 3 l
 
 at :: Int -> [a] -> Maybe a
-at i l = (l ^? ix i)
+at _ [] = Nothing
+at 0 l = Just $ head l
+at i l = at (i-1) (tail l)
 
 findTemperatures :: String -> [[String]]
 findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)"

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -76,7 +76,7 @@ findReplacements = map parseRegexResult . findTemperatures
   where parseRegexResult l = (l!!0, Temperature (read (l!!1)) (parseTempUnit (l!!2)))
 
 findTemperatures :: String -> [[String]]
-findTemperatures s = s =~  "(-?[0-9]*) *°(C|F)"
+findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°(C|F)"
 
 parseTempUnit :: String -> TempUnit
 parseTempUnit "C" = C

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -79,12 +79,12 @@ findReplacements = map fromJust . filter isJust . map parseRegexResult . findTem
   where parseRegexResult r = to3Tuple r >>= parseTemperature
 
 to3Tuple :: [a] -> Maybe (a, a, a)
-to3Tuple [a,b,c] = return (a,b,c)
-to3Tuple _ = fail $ "can't convert non 3-element list to 3-Tuple"
+to3Tuple [a,b,c] = Just (a,b,c)
+to3Tuple _ = Nothing
 
 parseTemperature :: (String,String,String) -> Maybe (String, Temperature)
 parseTemperature (s,v,u) = case isJust maybeValue && isJust maybeUnit of
-  True -> return (s, Temperature (fromJust maybeValue) (fromJust maybeUnit))
+  True -> Just (s, Temperature (fromJust maybeValue) (fromJust maybeUnit))
   False -> Nothing
   where maybeValue = readMaybe v
         maybeUnit = parseTempUnit u
@@ -105,9 +105,9 @@ findTemperatures :: String -> [[String]]
 findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)"
 
 parseTempUnit :: String -> Maybe TempUnit
-parseTempUnit "C" = return C
-parseTempUnit "F" = return F
-parseTempUnit x = fail $ "couldn't parse tempUnit: " ++ x
+parseTempUnit "C" = Just C
+parseTempUnit "F" = Just F
+parseTempUnit _ = Nothing
 
 data Temperature = Temperature Int TempUnit
 

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -100,12 +100,12 @@ parseTempUnit "C" = Just C
 parseTempUnit "F" = Just F
 parseTempUnit _ = Nothing
 
-data Temperature = Temperature Int TempUnit
+data Temperature = Temperature Int TempUnit deriving Eq
 
 instance Show Temperature where
   show (Temperature value unit) = show value ++ show unit
 
-data TempUnit = C | F
+data TempUnit = C | F deriving Eq
 
 instance Show TempUnit where
   show C = "°C"

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -84,12 +84,16 @@ parseTempUnit "F" = F
 parseTempUnit x = error $ "couldn't parse tempUnit: " ++ x
 
 data Temperature = Temperature Int TempUnit
+
 instance Show Temperature where
   show (Temperature value unit) = show value ++ show unit
+
 data TempUnit = C | F
+
 instance Show TempUnit where
   show C = "°C"
   show F = "°F"
+
 toTempUnit :: TempUnit -> Temperature -> Temperature
 toTempUnit C (Temperature x F) = Temperature (fahrenheitToCelsius x) C
 toTempUnit F (Temperature x C) = Temperature (celsiusToFahrenheit x) F
@@ -97,5 +101,6 @@ toTempUnit _ t = t
 
 fahrenheitToCelsius :: Int -> Int
 fahrenheitToCelsius = round . (/1.8) . (+(-32)) . fromIntegral
+
 celsiusToFahrenheit :: Int -> Int
 celsiusToFahrenheit = round . (+32) . (*1.8) . fromIntegral

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -93,7 +93,7 @@ at i l = at (i-1) (tail l)
 
 -- returns a list of matches, where every match is a list of the regex groups
 findTemperatures :: String -> [[String]]
-findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)( |$)"
+findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)([ .!?]|$)"
 
 parseTempUnit :: String -> Maybe TempUnit
 parseTempUnit "C" = Just C

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -91,6 +91,7 @@ at _ [] = Nothing
 at 0 l = Just $ head l
 at i l = at (i-1) (tail l)
 
+-- returns a list of matches, where every match is a list of the regex groups
 findTemperatures :: String -> [[String]]
 findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)"
 

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -86,11 +86,6 @@ parseTemperature (s, v, u) = case (readMaybe v, parseTempUnit u) of
   (Just value, Just unit) -> Just (s, Temperature value unit)
   _ -> Nothing
 
-at :: Int -> [a] -> Maybe a
-at _ [] = Nothing
-at 0 l = Just $ head l
-at i l = at (i-1) (tail l)
-
 -- returns a list of matches, where every match is a list of the regex groups
 findTemperatures :: String -> [[String]]
 findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)([ .!?]|$)"

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -57,12 +57,15 @@ convertIngredientToImperial ingr =
     Gallon  -> ingr
     Other _ -> ingr
 
-    
-convertTemperatureToMetric :: String -> String
-convertTemperatureToMetric s = unpack $ foldl replaceTemperature (pack s) (fmap packText $ fmap convertReplacement (findReplacements s))
+
+convertTemperatureToMetric = convertTemperature C
+convertTemperatureToImperial = convertTemperature F
+
+convertTemperature :: TempUnit -> String -> String
+convertTemperature u s = unpack $ foldl replaceTemperature (pack s) (fmap packText $ fmap convertReplacement (findReplacements s))
   where packText (s1, s2) = (pack s1, pack s2)
         replaceTemperature text (old, new) = replace old new text
-        convertReplacement = fmap $ show . toTempUnit C
+        convertReplacement = fmap $ show . toTempUnit u
 
 findReplacements :: String -> [(String, Temperature)]
 findReplacements = map parseRegexResult . findTemperatures

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -76,7 +76,7 @@ findReplacements = map parseRegexResult . findTemperatures
   where parseRegexResult l = (l!!0, Temperature (read (l!!1)) (parseTempUnit (l!!2)))
 
 findTemperatures :: String -> [[String]]
-findTemperatures s = s =~  "([0-9]*) *°(C|F)"
+findTemperatures s = s =~  "(-?[0-9]*) *°(C|F)"
 
 parseTempUnit :: String -> TempUnit
 parseTempUnit "C" = C

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -2,7 +2,7 @@ module UnitConversions where
 
 import Types
 import Data.Text (replace, pack, unpack)
-import Text.Regex.Posix ((=~))
+import Text.Regex.TDFA ((=~))
 
 -- NOTE: Here, "imperial" means "U.S. Customary". Conversion to British,
 -- Australian, Canadian, etc. imperial units is not yet implemented.

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -93,8 +93,7 @@ instance Show TempUnit where
 toTempUnit :: TempUnit -> Temperature -> Temperature
 toTempUnit C (Temperature x F) = Temperature (fahrenheitToCelsius x) C
 toTempUnit F (Temperature x C) = Temperature (celsiusToFahrenheit x) F
-toTempUnit C (Temperature x C) = (Temperature x C)
-toTempUnit F (Temperature x F) = (Temperature x F)
+toTempUnit _ t = t
 
 fahrenheitToCelsius :: Int -> Int
 fahrenheitToCelsius = round . (/1.8) . (+(-32)) . fromIntegral

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -78,7 +78,7 @@ findReplacements = mapMaybe parseRegexResult . findTemperatures
   where parseRegexResult r = to3Tuple r >>= parseTemperature
 
 to3Tuple :: [a] -> Maybe (a, a, a)
-to3Tuple [a, b, c] = Just (a, b, c)
+to3Tuple (a:b:c: _) = Just (a, b, c)
 to3Tuple _ = Nothing
 
 parseTemperature :: (String, String, String) -> Maybe (String, Temperature)
@@ -93,7 +93,7 @@ at i l = at (i-1) (tail l)
 
 -- returns a list of matches, where every match is a list of the regex groups
 findTemperatures :: String -> [[String]]
-findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)"
+findTemperatures s = s =~  "(-?[0-9]{1,3}) ?°?(C|F)( |$)"
 
 parseTempUnit :: String -> Maybe TempUnit
 parseTempUnit "C" = Just C

--- a/src/UnitConversions.hs
+++ b/src/UnitConversions.hs
@@ -59,8 +59,9 @@ convertIngredientToImperial ingr =
 
     
 convertTemperatureToMetric :: String -> String
-convertTemperatureToMetric s = unpack $ foldl (\text (n,r) -> replace n r text) (pack s) (fmap packText $ findReplacements s)
+convertTemperatureToMetric s = unpack $ foldl replaceTemperature (pack s) (fmap packText $ findReplacements s)
       where packText (s1, s2) = (pack s1, pack s2)
+            replaceTemperature text (old, new) = replace old new text
 
 findReplacements :: String -> [(String, String)]
 findReplacements = (map ((fmap translateTemperature) . parseRegexResult)) . findTemperatures

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,4 +12,5 @@ main = T.defaultMain $ T.testGroup "Tests" [ ReadConfig.Tests.tests
                                            , Types.Tests.tests
                                            , Utils.Tests.tests
                                            , UnitConversions.Tests.tests
+                                           , UnitConversions.Tests.temperatureUnitTests
                                            ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,6 +11,5 @@ main :: IO ()
 main = T.defaultMain $ T.testGroup "Tests" [ ReadConfig.Tests.tests
                                            , Types.Tests.tests
                                            , Utils.Tests.tests
-                                           , UnitConversions.Tests.tests
-                                           , UnitConversions.Tests.temperatureUnitTests
+                                           , UnitConversions.Tests.test
                                            ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -40,4 +40,6 @@ temperatureUnitTests = testGroup "TemperatureConversions"
         (convertTemperatureToMetric "-20°F") @?= "-29°C"
     , testCase "Converting a temperature in a text with a space between the number and the unit" $
         (convertTemperatureToImperial "50 °C") @?= "122°F"
+    , testCase "Converting a temperature that doesn't have the degree sign" $
+        (convertTemperatureToImperial "50 C") @?= "122°F"
     ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -34,7 +34,7 @@ temperatureUnitTests = testGroup "TemperatureConversions"
         (convertTemperatureToMetric "preheat to 110°F") @?= "preheat to 43°C"
     , testCase "Converting °C to °F in a text" $
         (convertTemperatureToImperial "preheat to 43°C") @?= "preheat to 109°F"
-        -- because of rounding we get 110° when converting F -> C -> F
+        -- because of rounding we get 109°F when converting 110° F -> °C -> °F
 
     , testCase "Converting a negative temperature" $
         (convertTemperatureToMetric "-20°F") @?= "-29°C"

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -2,7 +2,9 @@ module UnitConversions.Tests where
 
 import           Test.Tasty                (TestTree, testGroup)
 import           Test.Tasty.QuickCheck     (testProperty)
+import           Test.Tasty.HUnit          (testCase)
 import           Test.QuickCheck           ((==>), (===))
+import           Test.HUnit                ((@?=))
 
 import           Types
 import           Instances()
@@ -17,11 +19,25 @@ isMetric unit =
     _  -> False
 
 tests :: TestTree
-tests = testGroup "UnitConversions"
+tests = testGroup "IngredientConversions"
     [ testProperty "testToMetric" $
         \x -> isMetric (unit x) ==>
                 convertIngredientToMetric x === x
     , testProperty "testToImperial" $
         \x -> not (isMetric (unit x)) ==>
                 convertIngredientToImperial x === x
+    ]
+
+temperatureUnitTests :: TestTree
+temperatureUnitTests = testGroup "TemperatureConversions"
+    [ testCase "Converting °F to °C in a text" $
+        (convertTemperatureToMetric "preheat to 110°F") @?= "preheat to 43°C"
+    , testCase "Converting °C to °F in a text" $
+        (convertTemperatureToImperial "preheat to 43°C") @?= "preheat to 109°F"
+        -- because of rounding we get 110° when converting F -> C -> F
+
+    , testCase "Converting a negative temperature" $
+        (convertTemperatureToMetric "-20°F") @?= "-29°C"
+    , testCase "Converting a temperature in a text with spaces between the number and the unit" $
+        (convertTemperatureToImperial "50  °C") @?= "122°F"
     ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -38,6 +38,6 @@ temperatureUnitTests = testGroup "TemperatureConversions"
 
     , testCase "Converting a negative temperature" $
         (convertTemperatureToMetric "-20°F") @?= "-29°C"
-    , testCase "Converting a temperature in a text with spaces between the number and the unit" $
-        (convertTemperatureToImperial "50  °C") @?= "122°F"
+    , testCase "Converting a temperature in a text with a space between the number and the unit" $
+        (convertTemperatureToImperial "50 °C") @?= "122°F"
     ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -42,4 +42,6 @@ temperatureUnitTests = testGroup "TemperatureConversions"
         (convertTemperatureToImperial "50 °C") @?= "122°F"
     , testCase "Converting a temperature that doesn't have the degree sign" $
         (convertTemperatureToImperial "50 C") @?= "122°F"
+    , testCase "Ignoring something that looks like a temperature but isn't" $
+        (convertTemperatureToImperial "50 Crabs") @?= "50 Crabs"
     ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -44,4 +44,6 @@ temperatureUnitTests = testGroup "TemperatureConversions"
         (convertTemperatureToImperial "50 C") @?= "122°F"
     , testCase "Ignoring something that looks like a temperature but isn't" $
         (convertTemperatureToImperial "50 Crabs") @?= "50 Crabs"
+    , testCase "Converting a temperature at the end of a sentence" $
+        (convertTemperatureToImperial "50 C. 50C? 50 C!") @?= "122°F 122°F 122°F"
     ]

--- a/test/UnitConversions/Tests.hs
+++ b/test/UnitConversions/Tests.hs
@@ -4,7 +4,7 @@ import           Test.Tasty                (TestTree, testGroup)
 import           Test.Tasty.QuickCheck     (testProperty)
 import           Test.Tasty.HUnit          (testCase)
 import           Test.QuickCheck           ((==>), (===))
-import           Test.HUnit                ((@?=), (@=?))
+import           Test.HUnit                ((@?=))
 import           Data.Tuple                (swap)
 
 import           Types
@@ -19,8 +19,14 @@ isMetric unit =
     G  -> True
     _  -> False
 
-tests :: TestTree
-tests = testGroup "IngredientConversions"
+test :: TestTree
+test = testGroup "ConversionTests"
+    [ ingredientTests
+    , temperatureUnitTests
+    , findingTemperaturesUnitTests ]
+
+ingredientTests :: TestTree
+ingredientTests = testGroup "IngredientConversions"
     [ testProperty "testToMetric" $
         \x -> isMetric (unit x) ==>
                 convertIngredientToMetric x === x
@@ -36,23 +42,24 @@ temperatureUnitTests = testGroup "TemperatureConversions"
     , testCase "Converting °C to °F in a text" $
         -- because of rounding we get 109°F when converting 110° F -> °C -> °F
         (convertTemperatureToImperial "preheat to 43°C") @?= "preheat to 109°F"
-        
-    , testCase "Recognizing temperatures in a text" $
-        let getTemperatures = map snd . findReplacements
-            testCases = [ ("250°C", [Temperature 250 C])
-                        , ("10 °C", [Temperature 10 C])
-                        , ("-10 °C", [Temperature (-10) C])
-                        , ("abc 15 C def", [Temperature 15 C])
-                        , ("5 C", [Temperature 5 C])
-                        , ("250C", [Temperature 250 C])
-                        , ("999°F", [Temperature 999 F])
-                        , ("34F", [Temperature 34 F])
-                        , ("250°C.", [Temperature 250 C])
-                        , ("250°C!", [Temperature 250 C])
-                        , ("250°C?", [Temperature 250 C])
-                        , ("10C 15F", [Temperature 10 C, Temperature 15 F])
-                        , ("0 Frites", [])
-                        , ("250Crabs", [])
-                        , ("250 Crabs", [])] :: [(String, [Temperature])] in
-            sequence_ $ map (uncurry (@=?) . fmap getTemperatures . swap) testCases
     ]
+
+findingTemperaturesUnitTests :: TestTree
+findingTemperaturesUnitTests = testGroup "recognizing/ignoring temperatures in a test" $
+    let getTemperatures = map snd . findReplacements
+        cases = [ ("250°C", [Temperature 250 C])
+                , ("10 °C", [Temperature 10 C])
+                , ("-10 °C", [Temperature (-10) C])
+                , ("abc 15 C def", [Temperature 15 C])
+                , ("5 C", [Temperature 5 C])
+                , ("250C", [Temperature 250 C])
+                , ("999°F", [Temperature 999 F])
+                , ("34F", [Temperature 34 F])
+                , ("250°C.", [Temperature 250 C])
+                , ("250°C!", [Temperature 250 C])
+                , ("250°C?", [Temperature 250 C])
+                , ("10C 15F", [Temperature 10 C, Temperature 15 F])
+                , ("0 Frites", [])
+                , ("250Crabs", [])
+                , ("250 Crabs", [])] :: [(String, [Temperature])] in
+        map ((\(exp, test) -> testCase test (getTemperatures test @?= exp)) . swap) cases


### PR DESCRIPTION
Hi,
this is my first pull request and addresses issue #39.
It will only convert temperatures in the form of "110°F" or "90 °C" but not something like "40 degree fahrenheit" (for now).

I haven't worked with Haskell very much and am not familiar with the solution implied here:
>This might be a little more involved as it will require parsing [...]. Luckily, things like this are pretty straightforward in Haskell

I implemented it by matching the text with a regex and am not sure if this is the straigtforward solution.

I am happy about any feedback to this pr.