### PR TITLE
Use brightWhite instead of white

### DIFF
--- a/app/AddCLI.hs
+++ b/app/AddCLI.hs
@@ -234,8 +234,8 @@ theMap :: A.AttrMap
 theMap =
   A.attrMap
     V.defAttr
-    [ (E.editAttr, V.white `on` V.black),
-      (E.editFocusedAttr, V.black `on` V.white)
+    [ (E.editAttr, V.brightWhite `on` V.black),
+      (E.editFocusedAttr, V.black `on` V.brightWhite)
     ]
 
 appCursor :: St -> [T.CursorLocation Name] -> Maybe (T.CursorLocation Name)


### PR DESCRIPTION
`Vty.white` is ANSI color 7, which is around `#CCCCCC`.
`Vty.brightWhite` is ANSI 15, which is full white `#FFFFFF`.

brightWhite:
![image](https://github.com/LuxMiranda/herms/assets/12855406/fac7c977-bb16-4e99-be8b-4de3d3d5e4f7)

white:
![image](https://github.com/LuxMiranda/herms/assets/12855406/040b1a0b-f091-4d18-9bf5-f31e528c8721)
